### PR TITLE
Upgrade to Kotlin 1.5.21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,15 +1,15 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.jetbrains.kotlin.jvm").version("1.3.41")
+    id("org.jetbrains.kotlin.jvm").version("1.5.21")
 }
 
-version = "1.0.4"
+version = "1.1.0"
 group = "org.hashids"
 description = "Kotlin implementation of Hashids https://hashids.org"
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
#### Description

This change upgrades the library to Kotlin v1.5.21. The Gradle wrapper was bumped to v6.1.1, as 5.x isn't compatible with Kotlin v1.5.x.